### PR TITLE
CI sanity check: pip install pylint

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -63,4 +63,3 @@ jobs:
               pylint "$f"
             fi
           done
-

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -50,18 +50,14 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
-      - name: "Install pylint on Ubuntu"
-        run: |
-          sudo apt update
-          sudo apt install pylint -y
 
       - name: "Run pylint"
         run: |
           set -euxo pipefail
           cd ${{ github.workspace }}/
-          pylint --version
           make install
           source ./venv
+          pylint --version
           for f in $(find . \( -path ./.git -o -path ./iwpt_venv \) -prune -o -type f -print); do
             if file "$f" | grep "Python script" &>/dev/null; then
               pylint "$f"

--- a/.pylintrc
+++ b/.pylintrc
@@ -583,5 +583,5 @@ min-public-methods=2
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception

--- a/iwpt_bot.py
+++ b/iwpt_bot.py
@@ -33,7 +33,7 @@ def get_credential():
             content = fil.read()
             templ = content.splitlines()
             if len(templ) < 4:
-                raise Exception(CRED_FILE
+                raise ValueError(CRED_FILE
                                 + " is malformed. "
                                 + "It needs to contain at least 4 secrets")
             return [fil if env is None else env
@@ -183,8 +183,8 @@ def get_tweet_str_from_file(logfilepath):
     '''
     tweet_str = ''
     with open(logfilepath, encoding='utf-8') as logfile:
-        istweeted = (logfile.readline().strip() == '1')
-        isprime = (logfile.readline().strip() == '1')
+        istweeted = logfile.readline().strip() == '1'
+        isprime = logfile.readline().strip() == '1'
 
         for line in logfile:
             tweet_str = tweet_str + line

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,17 @@
+astroid==3.3.8
 certifi==2024.7.4
 charset-normalizer==2.0.12
+dill==0.3.9
 idna==3.7
+isort==5.13.2
+mccabe==0.7.0
 oauthlib==3.2.2
+platformdirs==4.3.6
+pylint==3.3.3
 requests==2.32.0
 requests-oauthlib==1.3.1
+setuptools==75.7.0
+tomlkit==0.13.2
 tweepy==4.14.0
 urllib3==1.26.19
+wheel==0.45.1


### PR DESCRIPTION
Instead of using the OS provided version of pylint, pip install it.